### PR TITLE
chore: update JDK version from openjdk17 to openjdk21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ allprojects {
 
     extensions.configure<JavaPluginExtension> {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(11))
+            languageVersion.set(JavaLanguageVersion.of(21))
         }
     }
 }
@@ -29,7 +29,7 @@ subprojects {
     tasks.withType<Javadoc>().configureEach {
         (options as StandardJavadocDocletOptions).apply {
             encoding = Charsets.UTF_8.toString()
-            links = listOf("https://docs.oracle.com/javase/11/docs/api/")
+            links = listOf("https://docs.oracle.com/javase/21/docs/api/")
             tags = listOf(
                 "apiNote:a:API Note:",
                 "implSpec:a:Implementation Requirements:",

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ItagItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ItagItem.java
@@ -81,7 +81,10 @@ public class ItagItem implements Serializable {
             new ItagItem(400, VIDEO_ONLY, MPEG_4, "1440p"),
             new ItagItem(266, VIDEO_ONLY, MPEG_4, "2160p"),
             new ItagItem(401, VIDEO_ONLY, MPEG_4, "2160p"),
-
+            new ItagItem(402, VIDEO_ONLY, MPEG_4, "4320p"), // can be 4320p60 as well
+            new ItagItem(571, VIDEO_ONLY, MPEG_4, "4320p"),
+            // can be 4320p60 HDR as well (1La4QzGeaaQ)
+            new ItagItem(402, VIDEO_ONLY, MPEG_4, "4320p60", 60),
             new ItagItem(278, VIDEO_ONLY, WEBM, "144p"),
             new ItagItem(242, VIDEO_ONLY, WEBM, "240p"),
             new ItagItem(243, VIDEO_ONLY, WEBM, "360p"),
@@ -91,28 +94,19 @@ public class ItagItem implements Serializable {
             new ItagItem(247, VIDEO_ONLY, WEBM, "720p"),
             new ItagItem(248, VIDEO_ONLY, WEBM, "1080p"),
             new ItagItem(271, VIDEO_ONLY, WEBM, "1440p"),
-            // #272 is either 3840x2160 (e.g. RtoitU2A-3E) or 7680x4320 (sLprVF6d7Ug)
-            new ItagItem(272, VIDEO_ONLY, WEBM, "2160p"),
             new ItagItem(302, VIDEO_ONLY, WEBM, "720p60", 60),
             new ItagItem(303, VIDEO_ONLY, WEBM, "1080p60", 60),
             new ItagItem(308, VIDEO_ONLY, WEBM, "1440p60", 60),
             new ItagItem(313, VIDEO_ONLY, WEBM, "2160p"),
-            new ItagItem(315, VIDEO_ONLY, WEBM, "2160p60", 60)
+            new ItagItem(315, VIDEO_ONLY, WEBM, "2160p60", 60),
+            new ItagItem(272, VIDEO_ONLY, WEBM, "4320p60", 60)
     };
 
     /*//////////////////////////////////////////////////////////////////////////
     // Utils
     //////////////////////////////////////////////////////////////////////////*/
 
-    public static boolean isSupported(final int itag) {
-        for (final ItagItem item : ITAG_LIST) {
-            if (itag == item.id) {
-                return true;
-            }
-        }
-        return false;
-    }
-
+    @Deprecated
     @Nonnull
     public static ItagItem getItag(final int itagId) throws ParsingException {
         for (final ItagItem item : ITAG_LIST) {
@@ -121,6 +115,65 @@ public class ItagItem implements Serializable {
             }
         }
         throw new ParsingException("itag " + itagId + " is not supported");
+    }
+
+    public static ItagItem getItag(final int itagId, final int averageBitrate,
+                                   final int fps, final String qualityLabel, final String mimeType)
+            throws ParsingException {
+
+        final String[] split = mimeType.split(";")[0].split("/");
+        final String streamType = split[0];
+        final String fileType = split[1];
+        final String codec = mimeType.split("\"")[1];
+
+        MediaFormat format = null;
+        ItagType itagType = null;
+
+        if (codec.contains(",")) { // muxed streams have both an audio and video codec
+            itagType = VIDEO;
+        } else {
+            if (streamType.equals("video")) {
+                itagType = VIDEO_ONLY;
+            }
+            if (streamType.equals("audio")) {
+                itagType = AUDIO;
+            }
+        }
+
+        if (itagType == VIDEO) {
+            if (fileType.equals("mp4")) {
+                format = MPEG_4;
+            }
+            if (fileType.equals("3gpp")) {
+                format = v3GPP;
+            }
+        }
+
+        if (itagType == VIDEO_ONLY) {
+            if (fileType.equals("mp4")) {
+                format = MPEG_4;
+            }
+            if (fileType.equals("webm")) {
+                format = WEBM;
+            }
+        }
+
+        if (itagType == AUDIO) {
+            if (fileType.equals("mp4") && (codec.startsWith("m4a") || codec.startsWith("mp4a"))) {
+                format = M4A;
+            }
+            if (fileType.startsWith("webm") && codec.equals("opus")) {
+                format = WEBMA_OPUS;
+            }
+        }
+
+        if (itagType == null || format == null) {
+            throw new ParsingException("Unknown mimeType: " + mimeType);
+        }
+
+        return itagType == AUDIO
+                ? new ItagItem(itagId, itagType, format, Math.round(averageBitrate / 1024f))
+                : new ItagItem(itagId, itagType, format, qualityLabel, fps);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1272,9 +1272,18 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         return streamingData.getArray(streamingDataKey).stream()
                 .filter(JsonObject.class::isInstance)
                 .map(JsonObject.class::cast)
+                .filter(formatData -> !formatData.getString("mimeType", "")
+                        .startsWith("text"))
                 .map(formatData -> {
                     try {
-                        final ItagItem itagItem = ItagItem.getItag(formatData.getInt("itag"));
+                        final int itag = formatData.getInt("itag");
+                        final int averageBitrate = formatData.getInt("averageBitrate");
+                        final int fps = formatData.getInt("fps");
+                        final String qualityLabel = formatData.getString("qualityLabel");
+                        final String mimeType = formatData.getString("mimeType");
+
+                        final ItagItem itagItem = ItagItem.
+                                getItag(itag, averageBitrate, fps, qualityLabel, mimeType);
                         if (itagItem.itagType == itagTypeWanted) {
                             return buildAndAddItagInfoToList(videoId, formatData, itagItem,
                                     itagItem.itagType, contentPlaybackNonce, poToken);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/JsonUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/JsonUtils.java
@@ -5,6 +5,7 @@ import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
 
+import com.grack.nanojson.LazyString;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
@@ -52,7 +53,7 @@ public final class JsonUtils {
     @Nonnull
     public static String getString(@Nonnull final JsonObject object, @Nonnull final String path)
             throws ParsingException {
-        return getInstanceOf(object, path, String.class);
+        return getInstanceOf(object, path, LazyString.class).toString();
     }
 
     @Nonnull
@@ -157,8 +158,8 @@ public final class JsonUtils {
 
     public static List<String> getStringListFromJsonArray(@Nonnull final JsonArray array) {
         return array.stream()
-                .filter(String.class::isInstance)
-                .map(String.class::cast)
+                .filter(LazyString.class::isInstance)
+                .map(Object::toString)
                 .collect(Collectors.toList());
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ okhttp = "5.3.2"
 protobuf-lib = "4.33.4"
 protobuf-plugin = "0.9.6"
 rhino = "1.8.1" # rhino 1.9.0 requires Android minSDK >= 26, see #1423
-teamnewpipe-nanojson = "e9d656ddb49a412a5a0a5d5ef20ca7ef09549996"
+teamnewpipe-nanojson = "a507525e549a836c3a8b6ab7090dca38e92942ef"
 
 [libraries]
 google-jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
@@ -27,7 +27,7 @@ junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 mozilla-rhino-core = { module = "org.mozilla:rhino", version.ref = "rhino" }
 mozilla-rhino-engine = { module = "org.mozilla:rhino-engine", version.ref = "rhino" }
-newpipe-nanojson = { module = "com.github.TeamNewPipe:nanojson", version.ref = "teamnewpipe-nanojson" }
+newpipe-nanojson = { module = "com.github.FireMasterK:nanojson", version.ref = "teamnewpipe-nanojson" }
 puppycrawl-checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" }
 squareup-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk17
+  - openjdk21


### PR DESCRIPTION
As we use Java21 in Piped, it is required that NewPipeExtractor uses Java 21 as well.